### PR TITLE
Fix path error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[EN](README.md) | [简中](docs/README_zh-CN.md) | [繁中](docs/README_zh-TW.md)| [日本語](docs/README_ja-JP.md)
+[EN](README.md) | [简中](docs/README_zh-CN.md) | [繁中](docs/README_zh-TW.md) | [日本語](docs/README_ja-JP.md)
 
 # FurinaImpact
 Server backend reimplementation for some game.

--- a/docs/README_ja-JP.md
+++ b/docs/README_ja-JP.md
@@ -1,4 +1,4 @@
-[EN](README.md) | [简中](docs/README_zh-CN.md) | [繁中](docs/README_zh-TW.md)| [日本語](docs/README_ja-JP.md)
+[EN](../README.md) | [简中](README_zh-CN.md) | [繁中](README_zh-TW.md) | [日本語](README_ja-JP.md)
 
 # FurinaImpact
 あるゲームのためのサーバーバックエンドの再実装。

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -1,4 +1,4 @@
-[EN](../README.md) | [简中](README_zh-CN.md) | [繁中](README_zh-TW.md)| [日本語](docs/README_ja-JP.md)
+[EN](../README.md) | [简中](README_zh-CN.md) | [繁中](README_zh-TW.md) | [日本語](README_ja-JP.md)
 
 # FurinaImpact
 用于某游戏的服务器后端重新实现。

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -1,4 +1,4 @@
-[EN](../README.md) | [简中](README_zh-CN.md) | [繁中](README_zh-TW.md)| [日本語](docs/README_ja-JP.md)
+[EN](../README.md) | [简中](README_zh-CN.md) | [繁中](README_zh-TW.md) | [日本語](README_ja-JP.md)
 
 # FurinaImpact
 用於某遊戲的伺服器後端重新實現。


### PR DESCRIPTION
Fixed the README 404 - Page Not Found issue caused by a path error in the readme.